### PR TITLE
Youtube thumbnails and team dyalog member page video posts

### DIFF
--- a/src/Version.aplf
+++ b/src/Version.aplf
@@ -1,2 +1,2 @@
  version←Version
- version←'0.4.0'
+ version←'0.5.0'

--- a/src/import_/GetYouTubeVideos.aplf
+++ b/src/import_/GetYouTubeVideos.aplf
@@ -12,5 +12,5 @@
     ⍝ ←: id  youtube_id  title  description  channel_id  channel  category_id  published_at  created_at  updated_at  updated_by
      id←r.Data.items.id
      _←{0=≢⍵:'' ⋄ #.DCMS.Catch ¯404,⊂'YouTube videos ID= (',⍵,') not available.'}1↓∊','∘,¨⍵/⍨~⍵∊id
-     ↑r.Data.items.((⊂id),snippet.(title description channelId channelTitle ⍬ publishedAt))   ⍝ ⍬ for category_id
+     ↑r.Data.items.((⊂id),snippet.(title description channelId channelTitle ⍬ publishedAt thumbnails.high.url))   ⍝ ⍬ for category_id
  }

--- a/src/import_/YouTubeImport.aplf
+++ b/src/import_/YouTubeImport.aplf
@@ -1,13 +1,10 @@
- msg←YouTubeImport ytid;url;key;video_data;Thumbnail;YTURL;exists;ids;columns;types;dt_cols
+ msg←YouTubeImport ytid;url;key;video_data;Thumbnail;exists;ids;columns;types;dt_cols
  msg←0   ⍝ OK
 ⍝ TODO: data caching with eTags
  url←#.GLOBAL.secrets.youtube
  key←#.GLOBAL.secrets.youtube_key
  video_data←GetYouTubeVideos ytid
- Thumbnail←('https://img.youtube.com/vi/','/maxresdefault.jpg',⍨⊢)
- YTURL←'https://youtu.be/'∘,
- video_data,←Thumbnail¨video_data[;1]   ⍝ Add thumbnail URL
- video_data,←YTURL¨video_data[;1]       ⍝ Add youtube_url
+ video_data,←'https://youtu.be/'∘,¨video_data[;1]       ⍝ Add youtube_url
  (exists ids)←ExistingYouTubeVideoIDs video_data[;1]
  (columns types)←ColumnInformation'youtube_videos'
  (columns types)←(~columns∊⊆'id' 'created_at' 'updated_at' 'updated_by')∘/¨columns types   ⍝ Remove these auto-generated columns

--- a/src/wp_/CPTPushTeamDyalogVideos.aplf
+++ b/src/wp_/CPTPushTeamDyalogVideos.aplf
@@ -1,4 +1,4 @@
- r←CPTPushTeamDyalogVideos;Clean;From;Latest;columns;cpt;d;exists;k;latest;new_cpt;posts;t;videos;in_database;unpublish;publish;grouped_posts;grouped_latest;publish_latest;unpublish_cpt;id;DateTime2DDN;thumbnail;HumanDateTime;HTMLimg;person_post_id;post_id;dcms_id;unpublish_posts;UnpublishCPT;person_id;current_posts;new_posts;update_columns;update_cpt;update_latest
+ r←CPTPushTeamDyalogVideos;Clean;From;Latest;columns;cpt;d;exists;k;latest;new_cpt;posts;t;videos;in_database;unpublish;publish;grouped_posts;grouped_latest;publish_latest;unpublish_cpt;id;DateTime2DDN;thumbnail;HumanDateTime;HTMLimg;person_post_id;post_id;dcms_id;unpublish_posts;UnpublishCPT;person_id;current_posts;new_posts;update_columns;update_cpt;update_latest;n
 ⍝ TODO: decide which videos defined in a JSON file OR "featured" marker on video itself
 
 ⍝ Use WordPress API to get post IDs corresponding to Team Dyalog members via their DCMS ID
@@ -13,15 +13,16 @@
  From←columns{⍵[;⍺⍺⍳⊆⍺]}
  Latest←{
      sorted←(⊂⍒'presentation_date'From ⍵)⌷⍵
-     latest←('person_id'From sorted){⊂(3⌊≢⍵)↑⍵}⌸sorted
-     ⊃⍪⌿latest⌿⍨⍺=≢¨latest
+     latest←('person_id'From sorted){⊂(n⌊≢⍵)↑⍵}⌸sorted
+     ⊃⍪⌿latest↑¨⍨n⌊≢¨latest
  }
  Clean←{⍵⌿⍨~∨/0=≢¨⍵}
  videos←∪Clean ##.SQL.Do cpt.team_dyalog_videos.sql
- latest←3 Latest videos
+ n←10
+ latest←n Latest videos
  posts←CPTGet'team-dyalog-videos'
 ⍝ Create 2 masks - posts to unpublish AND latest to upload
- ((update_latest update_columns)unpublish_posts publish_latest)←posts CompareTeamDyalogVideos latest
+ ((update_latest update_columns)unpublish_posts publish_latest)←posts(n _CompareTeamDyalogVideos)latest
 
  publish_latest←TeamDyalogVideosCustomFields publish_latest columns
  update_latest←TeamDyalogVideosCustomFields update_latest update_columns

--- a/src/wp_/_CompareTeamDyalogVideos.aplo
+++ b/src/wp_/_CompareTeamDyalogVideos.aplo
@@ -1,14 +1,17 @@
- CompareTeamDyalogVideos←{
+ _CompareTeamDyalogVideos←{
 ⍝ ⍺: posts list of JSON objects
 ⍝ ⍵: latest videos matrix
+⍝ ⍺⍺: maximum number of team-dyalog-videos posts per person in WordPress
 ⍝ ←: (unpublish_posts publish_latest)
 ⍝ Compare existing wordpress posts with latest videos in database
-⍝ ensuring there are 3 latest videos in wordpress for a particular person (or none if there are less)
+⍝ ensuring there are at most 10 latest videos in wordpress for a particular person
 ⍝ return CPT post objects (from wordpress) and a matrix of latest videos (from the database) to be used to create HTTP requests
      (posts latest)←⍺ ⍵
+     n←⍺⍺
      0∊≢¨posts latest:posts latest
-     (person_id post_id)←↓⍉↑posts.(acf.(person_id post_id))
-     in_database←person_id∊'person_id'From videos   ⍝ Only process posts with person_id in retrieved videos
+     posts⌿⍨←0=∊posts.(⎕NC'HttpStatus')                                  ⍝ Ignore posts which failed to download
+     (person_id post_id)←↓⍉↑posts.acf.(person_id post_id)
+     in_database←person_id∊'person_id'From videos                        ⍝ Only process posts with person_id in retrieved videos
      ~∨/in_database:0 1
      grouped_posts←(in_database/person_id){⊂⍵}⌸in_database/posts
      grouped_latest←(∪in_database/person_id){latest⊂⍤⌿⍤1 2⍨⍺∘.=⍵}'person_id'From latest
@@ -20,16 +23,20 @@
      new_posts←⎕NS¨⍬⍨¨grouped_latest
      new_posts.ddn←DateTime2DDN¨'presentation_date'∘From¨grouped_latest
      new_posts.id←'media_id'∘From¨grouped_latest
-     (unpublish publish)←↓⍉↑current_posts(3 _ComputePublicationMasks)¨new_posts
+     (unpublish publish)←↓⍉↑current_posts(n _ComputePublicationMasks)¨new_posts
 
      publish_latest←⊃⍪⌿publish⌿¨grouped_latest
      unpublish_posts←⊃,/unpublish/¨grouped_posts
      update_posts←posts~unpublish_posts
+     TimeStamp2TS←⊃∘(//'-T:'∘⎕VFI)
+     update_posts⌷⍨∘⊂←⍒TimeStamp2TS¨update_posts.date   ⍝ Sort newest to oldest, so only latest post is updated if there are duplicate person_id media_id pairs
      update_id←update_posts.id
      (id pid)←↓⍉↑update_posts.(id acf.(person_id media_id))
      pid←↑pid
      lid←'media_id' 'person_id'From latest
      ulatest←(≢pid)≥pid⍳lid ⋄ upid←lid⍳pid
+     upid⌿⍨←upid≤≢lid
+     upid←{u←∪⍵ ⋄ u<⍥≢⍵:u⊣⎕←'WARNING: Duplicate team-dyalog-videos posts found' ⋄ u}upid
      update_id←id⌷⍨⊂upid⌿⍨(≢lid)≥upid
      update_latest←ulatest⌿latest
      update_columns←columns,⍨⊂'id' ⋄ update_latest,⍨←update_id

--- a/src/wp_/_ComputePublicationMasks.aplo
+++ b/src/wp_/_ComputePublicationMasks.aplo
@@ -14,12 +14,13 @@
 
        ⍝ Keep items where ⍺.id∩⍵.id
         ⍝ mask is 0 in this case
-       ⍝ Keep most recent 3 items
+       ⍝ Keep n most recent items
+       ⍝ Push items to make total up to max of n
      keep←⍺.id∊⍵.id
      push←~⍵.id∊⍺.id
      ddn←(keep/⍺.ddn),push/⍵.ddn
      i←⍳≢ddn
-     r←(keep,push)\i∊n↑⍒ddn             ⍝ Mask of n latest items between ⍺ and ⍵
+     r←(keep,push)\i∊(n⌊≢ddn)↑⍒ddn      ⍝ Mask of n latest items between ⍺ and ⍵
      (keep push)←↑∘r¨1 ¯1×≢¨keep push   ⍝ Partitioned into (≢⍺.X)(≢⍵.X) items
      (~keep)(push)
  }

--- a/tests/TestGetVideos.aplf
+++ b/tests/TestGetVideos.aplf
@@ -2,7 +2,7 @@
      ⎕←'Test GET videos'
      ⍺←'http://localhost:8081/' ⋄ url←(AddTrailingSlash ⍺),'videos'
      G←url∘HttpGet
-     fields←'description' 'event' 'category' 'presenter' 'title' 'url' 'youtube_id' 'published_at'
+     fields←'category' 'description' 'event' 'event_shortname' 'presented_at' 'presenter' 'published_at' 'thumbnail' 'title' 'url' 'youtube_id' 'youtube_url'
      _←Assert∧/fields∊(G'')[1].⎕NL-⍳9            ⍝ all videos
      vid←'/AFvfBE19OFg'                          ⍝ ⍰ known existing video youtube ID
      _←Assert∧/fields∊(G vid).⎕NL-⍳9             ⍝ single video


### PR DESCRIPTION
- Get high quality (hq) video thumbnail URLs from YouTube API
- Push between 0 and 10 latest videos for each team dyalog member as team-dyalog-videos posts in WordPress
