### PR TITLE
#108 team dyalog duplicates

### DIFF
--- a/APLSource/Version.aplf
+++ b/APLSource/Version.aplf
@@ -1,2 +1,2 @@
  version←Version
- version←'3.27.0'
+ version←'3.27.1'

--- a/APLSource/wp/BuildVideoPosts.aplf
+++ b/APLSource/wp/BuildVideoPosts.aplf
@@ -2,21 +2,21 @@
 ⍝ Construct HTTP POST body for WordPress team-dyalog-videos custom post type, based on SQL query results and existing posts
 ⍝ ⍵: person (id ⋄ dcms_id); existing posts (id ⋄ acf.media_id ⋄ acf.dcms_id); SQL query results
 ⍝ ←: (create delete) post objects to create or update, post IDs to delete
-    (person exists vids)←⍵
-    fields←'acf.media_id' 'acf.url' 'title' 'acf.thumbnail' 'acf.description' 'acf.presentation_date' 'acf.event_slug' 'acf.event_title' 'acf.person_id'
-    create←Table2JSON fields⍪vids
-    create.acf.post_id←(person.id,0)[person.acf.dcms_id⍳create.acf.person_id]                               ⍝ Person ID → WordPress Team Dyalog post ID
-    create⌿⍨←0≠create.acf.post_id                                                                           ⍝ Remove videos with no Team Dyalog member post
-    EventURL←{'<a href="/video-library/search?event=',⍺,'">',⍵,'</a>'}
-    create.acf.event←create.acf.event_slug EventURL¨create.acf.event_title                                   ⍝ event_link → HTML <a> tag
-    create.acf.url←'/video-library/watch/?v='∘,¨create.acf.url                                              ⍝ YouTube ID → video library URL
-    create.acf.thumbnail←create.title{'<img src="',⍵,'" title="',⍺,'" alt="',⍺,'" />'}¨create.acf.thumbnail   ⍝ Thumbnail as HTML <img> tag
-    create.date←create.acf.presentation_date                                                                ⍝ Presentation date → post date
-    create.acf.readable_date←'Mmmm YYYY'FormatDateTime 1 ⎕DT 2⊃¨'- :'∘⎕VFI¨create.acf.presentation_date     ⍝ Presentation date → human-readable datetime
-    create.id←{0=≢⍵:0 ⋄ (⍵.id,0)[⍵.acf.media_id⍳create.acf.media_id]}exists                                 ⍝ Set post ID to update existing posts.
-    {0=≢⍵:'' ⋄ ⍵.⎕EX⊂'id'}(0=create.id)/create                                                              ⍝ Remove post ID to create new posts.
-    create.status←⊂'publish'
-    0∊⍴exists: create ''
-    delete←exists⌿⍨(≢create)<create.acf.(media_id person_id)⍳exists.acf.(media_id person_id)
-    (create delete)
+     (person exists vids)←⍵
+     fields←'acf.media_id' 'acf.url' 'title' 'acf.thumbnail' 'acf.description' 'acf.presentation_date' 'acf.event_slug' 'acf.event_title' 'acf.person_id'
+     create←Table2JSON fields⍪vids
+     create.acf.post_id←(person.id,0)[person.acf.dcms_id⍳create.acf.person_id]                               ⍝ Person ID → WordPress Team Dyalog post ID
+     create⌿⍨←0≠create.acf.post_id                                                                           ⍝ Remove videos with no Team Dyalog member post
+     EventURL←{'<a href="/video-library/search?event=',⍺,'">',⍵,'</a>'}
+     create.acf.event←create.acf.event_slug EventURL¨create.acf.event_title                                   ⍝ event_link → HTML <a> tag
+     create.acf.url←'/video-library/watch/?v='∘,¨create.acf.url                                              ⍝ YouTube ID → video library URL
+     create.acf.thumbnail←create.title{'<img src="',⍵,'" title="',⍺,'" alt="',⍺,'" />'}¨create.acf.thumbnail   ⍝ Thumbnail as HTML <img> tag
+     create.date←create.acf.presentation_date                                                                ⍝ Presentation date → post date
+     create.acf.readable_date←'Mmmm YYYY'FormatDateTime 1 ⎕DT 2⊃¨'- :'∘⎕VFI¨create.acf.presentation_date     ⍝ Presentation date → human-readable datetime
+     create.id←{0=≢⍵:0 ⋄ (⍵.id,0)[⍵.acf.media_id⍳create.acf.media_id]}exists                                 ⍝ Set post ID to update existing posts.
+     _←{0=≢⍵:'' ⋄ ⍵.⎕EX⊂'id'}(0=create.id)/create                                                              ⍝ Remove post ID to create new posts.
+     create.status←⊂'publish'
+     0∊⍴exists:create''
+     delete←exists⌿⍨(≢create)<create.acf.(media_id person_id)⍳exists.acf.(media_id person_id)
+     (create delete)
  }

--- a/APLSource/wp/BuildVideoPosts.aplf
+++ b/APLSource/wp/BuildVideoPosts.aplf
@@ -1,0 +1,22 @@
+ BuildVideoPosts←{
+⍝ Construct HTTP POST body for WordPress team-dyalog-videos custom post type, based on SQL query results and existing posts
+⍝ ⍵: person (id ⋄ dcms_id); existing posts (id ⋄ acf.media_id ⋄ acf.dcms_id); SQL query results
+⍝ ←: (create delete) post objects to create or update, post IDs to delete
+    (person exists vids)←⍵
+    fields←'acf.media_id' 'acf.url' 'title' 'acf.thumbnail' 'acf.description' 'acf.presentation_date' 'acf.event_slug' 'acf.event_title' 'acf.person_id'
+    create←Table2JSON fields⍪vids
+    create.acf.post_id←(person.id,0)[person.acf.dcms_id⍳create.acf.person_id]                               ⍝ Person ID → WordPress Team Dyalog post ID
+    create⌿⍨←0≠create.acf.post_id                                                                           ⍝ Remove videos with no Team Dyalog member post
+    EventURL←{'<a href="/video-library/search?event=',⍺,'">',⍵,'</a>'}
+    create.acf.event←create.acf.event_slug EventURL¨create.acf.event_title                                   ⍝ event_link → HTML <a> tag
+    create.acf.url←'/video-library/watch/?v='∘,¨create.acf.url                                              ⍝ YouTube ID → video library URL
+    create.acf.thumbnail←create.title{'<img src="',⍵,'" title="',⍺,'" alt="',⍺,'" />'}¨create.acf.thumbnail   ⍝ Thumbnail as HTML <img> tag
+    create.date←create.acf.presentation_date                                                                ⍝ Presentation date → post date
+    create.acf.readable_date←'Mmmm YYYY'FormatDateTime 1 ⎕DT 2⊃¨'- :'∘⎕VFI¨create.acf.presentation_date     ⍝ Presentation date → human-readable datetime
+    create.id←{0=≢⍵:0 ⋄ (⍵.id,0)[⍵.acf.media_id⍳create.acf.media_id]}exists                                 ⍝ Set post ID to update existing posts.
+    {0=≢⍵:'' ⋄ ⍵.⎕EX⊂'id'}(0=create.id)/create                                                              ⍝ Remove post ID to create new posts.
+    create.status←⊂'publish'
+    0∊⍴exists: create ''
+    delete←exists⌿⍨(≢create)<create.acf.(media_id person_id)⍳exists.acf.(media_id person_id)
+    (create delete)
+ }

--- a/APLSource/wp/BuildVideoPosts.aplf
+++ b/APLSource/wp/BuildVideoPosts.aplf
@@ -13,7 +13,7 @@
      create.acf.thumbnail←create.title{'<img src="',⍵,'" title="',⍺,'" alt="',⍺,'" />'}¨create.acf.thumbnail   ⍝ Thumbnail as HTML <img> tag
      create.date←create.acf.presentation_date                                                                ⍝ Presentation date → post date
      create.acf.readable_date←'Mmmm YYYY'FormatDateTime 1 ⎕DT 2⊃¨'- :'∘⎕VFI¨create.acf.presentation_date     ⍝ Presentation date → human-readable datetime
-     create.id←{0=≢⍵:0 ⋄ (⍵.id,0)[⍵.acf.media_id⍳create.acf.media_id]}exists                                 ⍝ Set post ID to update existing posts.
+     create.id←{0=≢⍵:0 ⋄ (⍵.id,0)[⍵.acf.(media_id person_id)⍳create.acf.(media_id person_id)]}exists                                 ⍝ Set post ID to update existing posts.
      _←{0=≢⍵:'' ⋄ ⍵.⎕EX⊂'id'}(0=create.id)/create                                                              ⍝ Remove post ID to create new posts.
      create.status←⊂'publish'
      0∊⍴exists:create''

--- a/APLSource/wp/PushTeamDyalogVideos.aplf
+++ b/APLSource/wp/PushTeamDyalogVideos.aplf
@@ -23,31 +23,16 @@
      :Return
  :EndIf
 
- fields←'acf.media_id' 'acf.url' 'title' 'acf.thumbnail' 'acf.description' 'acf.presentation_date' 'acf.event_slug' 'acf.event_title' 'acf.person_id'
- posts←Table2JSON fields⍪vids
- posts.acf.post_id←(person.id,0)[person.acf.dcms_id⍳posts.acf.person_id]                               ⍝ Person ID → WordPress Team Dyalog post ID
- posts⌿⍨←0≠posts.acf.post_id                                                                           ⍝ Remove videos with no Team Dyalog member post
- EventURL←{'<a href="/video-library/search?event=',⍺,'">',⍵,'</a>'}
- posts.acf.event←posts.acf.event_slug EventURL¨posts.acf.event_title                                   ⍝ event_link → HTML <a> tag
- posts.acf.url←'/video-library/watch/?v='∘,¨posts.acf.url                                              ⍝ YouTube ID → video library URL
- posts.acf.thumbnail←posts.title{'<img src="',⍵,'" title="',⍺,'" alt="',⍺,'" />'}¨posts.acf.thumbnail   ⍝ Thumbnail as HTML <img> tag
- posts.date←posts.acf.presentation_date                                                                ⍝ Presentation date → post date
- posts.acf.readable_date←'Mmmm YYYY'FormatDateTime 1 ⎕DT 2⊃¨'- :'∘⎕VFI¨posts.acf.presentation_date     ⍝ Presentation date → human-readable datetime
- posts.id←{0=≢⍵:0 ⋄ (⍵.id,0)[⍵.acf.media_id⍳posts.acf.media_id]}exists                                 ⍝ Set post ID to update existing posts.
- {0=≢⍵:'' ⋄ ⍵.⎕EX⊂'id'}(0=posts.id)/posts                                                              ⍝ Remove post ID to create new posts.
- posts.status←⊂'publish'
+ (create delete)←BuildVideoPosts person exists vids
  r←⍬
 
 ⍝ The SQL query gets up to n videos per person
 ⍝ Existing WordPress posts which do not appear in the SQL query will be deleted
 ⍝ All posts from the SQL query will be created, or updated if they already exist
 
- :If ~0∊⍴exists
-     delete←exists⌿⍨(≢posts)<posts.acf.(media_id person_id)⍳exists.acf.(media_id person_id)
- :AndIf ~0∊⍴delete
+ :If ~0∊⍴delete
      r,←Delete¨'/wp/v2/team-dyalog-videos/'∘,¨⍕¨delete.id
  :EndIf
- create←posts
-
+ 
  bulk←'/wp/v2/team-dyalog-videos'DoBulk create
  r,←⊃,/bulk.responses

--- a/Admin/Tests/General/Test_PushTeamDyalog_DeleteStale.aplf
+++ b/Admin/Tests/General/Test_PushTeamDyalog_DeleteStale.aplf
@@ -1,0 +1,39 @@
+ Test_PushTeamDyalog_DeleteStale←{
+⍝ An existing team-dyalog-videos post whose (media_id, person_id) no longer
+⍝ appears in the current SQL result must be returned for deletion, while a
+⍝ still-current post is kept (updated) and not deleted.
+     Assert←##.Assert
+     wp←#.DCMS.wp
+
+  ⍝ --- Arrange ------------------------------------------------------
+     MakePerson←{(
+      id: ⊃⍵
+      acf: (dcms_id: ⊃⌽⍵)
+     )}
+     person←,MakePerson 1001 1
+
+  ⍝ Current SQL result: one video (media_id 100) for this member.
+     row←{100 'abc123' 'Talk A' 'thumb.png' 'A description' '2024-01-01 10:00:00' 'dyalog24' 'Dyalog ''24' ⍵}
+     vids←↑,⊂row 1
+
+  ⍝ Existing posts: one current (media_id 100) → kept/updated,
+  ⍝ one stale (media_id 200, not in the SQL result) → must be deleted.
+     MakeExisting←{(
+      id←⊃⍵
+      acf: (
+         media_id: 2⊃⍵
+         person_id: 3⊃⍵
+      )
+     )}
+     exists←MakeExisting¨(5001 100 1)(5002 200 1)
+
+  ⍝ --- Act ----------------------------------------------------------
+     (create delete)←wp.BuildVideoPosts person exists vids
+
+  ⍝ --- Assert -------------------------------------------------------
+     Assert 1=≢create:                ⍝ only the current video is published
+     Assert(,5001)≡create.id:         ⍝ current post is updated, not recreated
+     Assert 1=≢delete:                ⍝ exactly one stale post removed
+     Assert(,5002)≡delete.id:         ⍝ and it is the stale one
+     1
+ }

--- a/Admin/Tests/General/Test_PushTeamDyalog_DeleteStale.aplf
+++ b/Admin/Tests/General/Test_PushTeamDyalog_DeleteStale.aplf
@@ -7,24 +7,24 @@
 
   ⍝ --- Arrange ------------------------------------------------------
      MakePerson←{(
-      id: ⊃⍵
-      acf: (dcms_id: ⊃⌽⍵)
-     )}
+             id:⊃⍵
+             acf:(dcms_id:⊃⌽⍵)
+         )}
      person←,MakePerson 1001 1
 
   ⍝ Current SQL result: one video (media_id 100) for this member.
-     row←{100 'abc123' 'Talk A' 'thumb.png' 'A description' '2024-01-01 10:00:00' 'dyalog24' 'Dyalog ''24' ⍵}
+     row←{100 'abc123' 'Talk A' 'thumb.png' 'A description' '2024-01-01 10:00:00' 'dyalog24' 'Dyalog ''24'⍵}
      vids←↑,⊂row 1
 
   ⍝ Existing posts: one current (media_id 100) → kept/updated,
   ⍝ one stale (media_id 200, not in the SQL result) → must be deleted.
      MakeExisting←{(
-      id←⊃⍵
-      acf: (
-         media_id: 2⊃⍵
-         person_id: 3⊃⍵
-      )
-     )}
+             id:⊃⍵
+             acf:(
+                 media_id:2⊃⍵
+                 person_id:3⊃⍵
+             )
+         )}
      exists←MakeExisting¨(5001 100 1)(5002 200 1)
 
   ⍝ --- Act ----------------------------------------------------------

--- a/Admin/Tests/General/Test_PushTeamDyalog_MultiPresenter.aplf
+++ b/Admin/Tests/General/Test_PushTeamDyalog_MultiPresenter.aplf
@@ -1,0 +1,35 @@
+ Test_PushTeamDyalog_MultiPresenter←{
+⍝ Issue #108: a video presented by two Team Dyalog members must be
+⍝ published as a post for BOTH members on a clean publish.
+     Assert←##.Assert
+     wp←#.DCMS.wp
+
+  ⍝ --- Arrange ------------------------------------------------------
+  ⍝ Two members. acf.dcms_id is the DCMS person id used by the SQL query;
+  ⍝ .id is their WordPress team-dyalog post id.
+     MakePerson←{(
+      id: ⊃⍵
+      acf: (dcms_id: ⊃⌽⍵)
+     )}
+     person←MakePerson¨(1001 1)(1002 2)
+
+  ⍝ No existing team-dyalog-videos posts: this is a clean publish.
+     exists←⍬
+
+  ⍝ One video (media_id 100) presented by both members (pers_id 1 and 2),
+  ⍝ so the SQL result has two rows differing only in pers_id. Columns match
+  ⍝ the SELECT in PushTeamDyalogVideos:
+  ⍝   media_id ytid title thumbnail description presented_at event_link event_title pers_id
+     row←{100 'abc123' 'Talk A' 'thumb.png' 'A description' '2024-01-01 10:00:00' 'dyalog24' 'Dyalog ''24' ⍵}
+     vids←↑(row 1)(row 2)
+
+  ⍝ --- Act ----------------------------------------------------------
+     (create delete)←wp.BuildVideoPosts person exists vids
+
+  ⍝ --- Assert -------------------------------------------------------
+     Assert 2=≢create:                          ⍝ one post per presenter
+     Assert 0=≢delete:                          ⍝ nothing to delete on a clean publish
+     Assert(1001 1002)≡create.acf.post_id:      ⍝ each linked to the right member's WP post
+     Assert ∧/0=create.⎕NC⊂'id':                ⍝ new posts carry no id (created, not updated)
+     1
+ }

--- a/Admin/Tests/General/Test_PushTeamDyalog_MultiPresenterUpdate.aplf
+++ b/Admin/Tests/General/Test_PushTeamDyalog_MultiPresenterUpdate.aplf
@@ -1,0 +1,37 @@
+ Test_PushTeamDyalog_MultiPresenterUpdate←{
+⍝ Issue #108 (the duplicate-producing case): when both posts already exist,
+⍝ each presenter's post must UPDATE its own WordPress post. The bug keys the
+⍝ existing-post lookup on media_id only, so two presenters of one video both
+⍝ resolve to the same existing id and collide.
+     Assert←##.Assert
+     wp←#.DCMS.wp
+
+  ⍝ --- Arrange ------------------------------------------------------
+     MakePerson←{(
+      id: ⊃⍵
+      acf: (dcms_id: ⊃⌽⍵)
+     )}
+     person←MakePerson¨(1001 1)(1002 2)
+
+  ⍝ Two existing posts for the SAME video (media_id 100), one per presenter.
+     MakeExisting←{(
+      id: ⊃⍵
+      acf: (
+         media_id: 2⊃⍵
+         person_id: 3⊃⍵
+      )
+     )}
+     exists←MakeExisting¨(5001 100 1)(5002 100 2)
+
+     row←{100 'abc123' 'Talk A' 'thumb.png' 'A description' '2024-01-01 10:00:00' 'dyalog24' 'Dyalog ''24' ⍵}
+     vids←↑(row 1)(row 2)
+
+  ⍝ --- Act ----------------------------------------------------------
+     (create delete)←wp.BuildVideoPosts person exists vids
+
+  ⍝ --- Assert -------------------------------------------------------
+     Assert 2=≢create:                          ⍝ still one post per presenter
+     Assert 0=≢delete:                          ⍝ both existing posts remain referenced
+     Assert(5001 5002)≡create.id:               ⍝ each updates its OWN post (bug → 5001 5001)
+     1
+ }


### PR DESCRIPTION
* refactor wordpress code to build team dyalog custom post objects in order to be testable
* tests for creation, update and delete scenarios